### PR TITLE
feature/add_type_hint

### DIFF
--- a/pyscalambda/scalambdable.py
+++ b/pyscalambda/scalambdable.py
@@ -10,12 +10,11 @@ from pyscalambda.utility import convert_oprand, vmap
 def scalambdable_func(fn, *funcs):
     """
     :type fn: (T)->U
-    :type funcs: list[(Any)->Any]
+    :type funcs: ((Any)->Any, ...)
     :rtype: (T)->U
     """
-    @functools.wraps(fn)
-    def wraps(*args, **kwargs):
-        for f in reversed([fn] + funcs):
+    def wrapped(*args, **kwargs):
+        for f in reversed((fn,) + funcs):
             def is_scalambda_object(x):
                 return issubclass(x.__class__, Formula)
             if any(map(is_scalambda_object, args)) or any(map(is_scalambda_object, kwargs.values())):
@@ -25,4 +24,4 @@ def scalambdable_func(fn, *funcs):
                 args = [f(*args, **kwargs)]
                 kwargs = {}
         return args[0]
-    return wraps
+    return wrapped if funcs else functools.wraps(fn)(wrapped)

--- a/pyscalambda/scalambdable.py
+++ b/pyscalambda/scalambdable.py
@@ -8,6 +8,11 @@ from pyscalambda.utility import convert_oprand, vmap
 
 
 def scalambdable_func(fn, *funcs):
+    """
+    :type fn: (T)->U
+    :type funcs: list[(Any)->Any]
+    :rtype: (T)->U
+    """
     @functools.wraps(fn)
     def wraps(*args, **kwargs):
         for f in reversed([fn] + funcs):

--- a/pyscalambda/scalambdable.py
+++ b/pyscalambda/scalambdable.py
@@ -7,10 +7,10 @@ from pyscalambda.formula_nodes import FunctionCall
 from pyscalambda.utility import convert_oprand, vmap
 
 
-def scalambdable_func(*funcs):
-    @functools.wraps(funcs[0])
+def scalambdable_func(fn, *funcs):
+    @functools.wraps(fn)
     def wraps(*args, **kwargs):
-        for f in reversed(funcs):
+        for f in reversed([fn] + funcs):
             def is_scalambda_object(x):
                 return issubclass(x.__class__, Formula)
             if any(map(is_scalambda_object, args)) or any(map(is_scalambda_object, kwargs.values())):

--- a/pyscalambda/scalambdable.py
+++ b/pyscalambda/scalambdable.py
@@ -9,6 +9,8 @@ from pyscalambda.utility import convert_oprand, vmap
 
 def scalambdable_func(fn, *funcs):
     """
+    Wrap function to scalambdable.
+
     :type fn: (T)->U
     :type funcs: ((Any)->Any, ...)
     :rtype: (T)->U


### PR DESCRIPTION
scalambdable_funcに渡した関数の返り値の型から補完できるように
sphinx styleのtype annotationを追加しました.

typeの書き方にstandardなものが無いのでpycharmが補完に用いることができるスタイルにしました.
https://www.jetbrains.com/help/pycharm/2016.3/type-hinting-in-pycharm.html#legacy

利便性のために実際に返す型とは違う型を返しています.