### PR TITLE
クラスのメンバへのアクセスへ対応する

### DIFF
--- a/pyscalambda/base_formula.py
+++ b/pyscalambda/base_formula.py
@@ -46,6 +46,11 @@ class BaseFormula(object):
             )
         return f
 
+    def do_getattr(self, name):
+        GetAttr = import_module("pyscalambda.formula_nodes").GetAttr
+
+        return GetAttr(self, name)
+
     def __add__(self, other):
         return self.do_operator2(other, "+")
 

--- a/pyscalambda/base_formula.py
+++ b/pyscalambda/base_formula.py
@@ -169,10 +169,10 @@ class BaseFormula(object):
     def __invert__(self):
         return self.do_operator1("~")
 
-    def __getattr__(self, method):
-        if method == '__setstate__' or method == 'id':
+    def __getattr__(self, name):
+        if name == '__setstate__' or name == 'id':
             return None
-        return self.do_methodcall(method)
+        return self.do_getattr(name)
 
     def __getitem__(self, key):
         return self.do_getitem(key)

--- a/tests/test_underscore.py
+++ b/tests/test_underscore.py
@@ -262,3 +262,11 @@ class UnderscoreTest(TestCase):
         not_formula_and_ok(not not_(_.or_(SC(False)))(True))
         not_formula_and_ok(not not_(_.or_(SC(True)))(True))
 
+    def test_get_attribute(self):
+        class A(object):
+            def __init__(self, x):
+                self.x = x
+
+        a = A(10)
+        not_formula_and_eq(_.x.M(a), 10)
+        not_formula_and_eq((_.x + 1)(a), 11)

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     flake8-docstrings>=0.2.7
     flake8-import-order>=0.9
 commands =
-    flake8 pyscalambda/ setup.py --max-line-length=119 --ignore=D100,D101,D102,D103,D104,D105
+    flake8 pyscalambda/ setup.py --max-line-length=119 --ignore=D100,D101,D102,D103,D104,D105,D205,D400


### PR DESCRIPTION
```py3
class A(object):
    def __init__(self, x):
        self.x = x

a = A(10)
(_.x  + 1)(a) # == 11
```

これを通るようにする。

アクセスが最後Formulaになってしまう場合は呼び出しが一意に決まらない用にMをつけるようにするような実装にした。

```py3
class A(object):
    def __init__(self, x):
        self.x = x

a = A(10)
(_.x)(a) # 10にはならない。これはまだMethodCallになっている
(_.x.M)(a) # == 10
```

このPRによって #5  を解決する。